### PR TITLE
Enhance FileSystem by integration of sb-resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "eslint": "^2.4.0",
     "babel-eslint": "^6.0.0-beta.6",
     "babel-preset-steelbrain": "^2.0.1",
+    "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.0.2",
     "eslint-plugin-react": "^4.2.1",
     "ucompiler": "^3.1.8",

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/steelbrain/pundle#readme",
   "dependencies": {
-    "resolve": "^1.1.7",
     "sb-promisify": "^1.3.0"
   }
 }

--- a/packages/fs/src/index.js
+++ b/packages/fs/src/index.js
@@ -19,20 +19,11 @@ class FileSystem {
   stat(path: string): Promise<FS.Stats> {
     return promisedFS.stat(path)
   }
-  statSync(path: string): FS.Stats {
-    return FS.statSync(path)
-  }
   resolve(moduleName: string, basedir: string): Promise<string> {
     return promisedResolve(moduleName, { basedir })
   }
-  resolveSync(moduleName: string, basedir: string): string {
-    return resolve.sync(moduleName, { basedir })
-  }
   async readFile(filePath: string): Promise<string> {
     return (await promisedFS.readFile(filePath)).toString('utf8')
-  }
-  readFileSync(filePath: string): string {
-    return FS.readFileSync(filePath).toString('utf8')
   }
 }
 

--- a/packages/pundle/package.json
+++ b/packages/pundle/package.json
@@ -32,9 +32,9 @@
     "babel-traverse": "^6.7.4",
     "babylon": "^6.7.0",
     "pundle-fs": "0.0.1",
-    "resolve": "^1.1.7",
     "sb-event-kit": "^1.1.2",
     "sb-memoize": "^1.0.1",
-    "sb-promisify": "^1.2.0"
+    "sb-promisify": "^1.2.0",
+    "sb-resolve": "^1.0.0"
   }
 }

--- a/packages/pundle/src/index.js
+++ b/packages/pundle/src/index.js
@@ -20,7 +20,7 @@ class Pundle {
   constructor(config: Pundle$Config) {
     this.config = normalizeConfig(config)
 
-    this.fileSystem = new FileSystem(new this.config.FileSystem(this.config))
+    this.fileSystem = new FileSystem(this.config, new this.config.FileSystem(this.config))
     this.path = new Path(this.config, this.fileSystem)
     this.emitter = new Emitter()
     this.subscriptions = new CompositeDisposable()

--- a/packages/pundle/src/path.js
+++ b/packages/pundle/src/path.js
@@ -2,7 +2,7 @@
 
 /* @flow */
 
-import resolve from 'resolve'
+import { isCore } from 'sb-resolve'
 import { CompositeDisposable, Emitter, Disposable } from 'sb-event-kit'
 import { posix as PosixPath } from 'path'
 import type FileSystem from './file-system'
@@ -35,10 +35,7 @@ export default class Path {
     return filePath
   }
   async resolveModule(moduleName: string, basedir: string): Promise<string> {
-    if (this.config.resolve.alias[moduleName]) {
-      moduleName = this.config.resolve.alias[moduleName]
-    }
-    if (resolve.isCore(moduleName)) {
+    if (isCore(moduleName)) {
       throw new Error('Module is core')
     }
     const event = { moduleName, basedir, path: '' }

--- a/packages/pundle/src/types.js
+++ b/packages/pundle/src/types.js
@@ -6,20 +6,14 @@ import type { Stats } from 'fs'
 
 export type Pundle$FileSystem = {
   stat: ((path: string) => Promise<Stats>),
-  statSync: ((path: string) => Stats),
-  resolve: ((moduleName: string, basedir: string) => Promise<string>),
-  resolveSync: ((moduleName: string, basedir: string) => string),
   readFile: ((filePath: string) => Promise<string>),
-  readFileSync: ((filePath: string) => string)
 }
 
 export type Pundle$Config = {
   entry: Array<string>,
   rootDirectory: string,
   FileSystem: Function,
-  resolve: {
-    alias: Object // <string, string>
-  }
+  resolve: Object
 }
 
 // Not used anywhere
@@ -27,9 +21,7 @@ export type Pundle$Config$User = {
   entry: string | Array<string>,
   rootDirectory: string,
   FileSystem?: Function,
-  resolve?: {
-    alias?: Object
-  }
+  resolve?: Object
 }
 
 export type Pundle$Module = {


### PR DESCRIPTION
This also removes the sync file system operations as we don't use them anyway.
Using [sb-resolve](https://github.com/steelbrain/resolve/) gives us tons of stability and customizability

TLDR; We support all of webpack's `resolve` configuration now
