### PR TITLE
:new: TypeScript plugin

### DIFF
--- a/packages/pundle/README.md
+++ b/packages/pundle/README.md
@@ -70,6 +70,7 @@ pundle.loadPlugins([
   return pundle.compile()
 }).then(function() {
   pundle.loadLoaders([
+    // These are just examples.  pundle-coffee and pundle-less don't exist yet =)
     { extensions: ['.coffee'], loader: require('pundle-coffee') },
     { extensions: ['.less'], loader: require('pundle-less') },
   ])

--- a/packages/typescript/.npmignore
+++ b/packages/typescript/.npmignore
@@ -1,0 +1,5 @@
+.idea
+node_modules
+.DS_Store
+*.log
+/src

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -1,0 +1,27 @@
+# `typescript-pundle`
+
+TypeScript transformer for Pundle
+
+## Installation
+
+```
+npm install --save typescript-pundle
+```
+
+## Usage
+
+```
+pundle.loadPlugins([
+  ['typescript-pundle', {
+    ignored?: RegExp,
+    extensions?: ['.js'],
+    config: {
+      ... TypeScript config ...
+    }
+  }]
+]).then(() => console.log('Plugin loaded successfully'))
+```
+
+## License
+
+This project is licensed under the terms of MIT License. See the LICENSE file at the root of the Github repo for more info.

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "typescript-pundle",
+  "version": "1.0.0",
+  "description": "TypeScript transformer for Pundle",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "apm test",
+    "lint": "eslint ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/motion/pundle.git"
+  },
+  "contributors": [
+    "appsforartists",
+    "steelbrain"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/motion/pundle/issues"
+  },
+  "homepage": "https://github.com/motion/pundle#readme",
+  "dependencies": {
+    "typescript": "^2.0.7"
+  }
+}

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -1,0 +1,38 @@
+/* @flow */
+
+import Path from 'path'
+import * as ts from 'typescript'
+
+export default function getTypeScriptTransformer(pundle: Object, parameters: Object = {}) {
+  if (parameters.ignored) {
+    if (!(parameters.ignored instanceof RegExp)) {
+      throw new Error('parameters.ignored must be a RegExp')
+    }
+  } else {
+    parameters.ignored = /(node_modules|bower_components)/
+  }
+
+  if (parameters.extensions) {
+    if (!Array.isArray(parameters.extensions)) {
+      throw new Error('parameters.extensions must be an Array')
+    }
+  } else {
+    parameters.extensions = ['.ts', '.tsx']
+  }
+
+  pundle.onBeforeProcess(function(event) {
+    if (event.filePath.indexOf('$root') !== 0 || event.filePath.match(parameters.ignored) || parameters.extensions.indexOf(Path.extname(event.filePath)) === -1) {
+      return
+    }
+
+    // docs at
+    // https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API
+    const processed = ts.transpileModule(
+      event.contents,
+      Object.assign({}, parameters.config)
+    )
+
+    event.contents = processed.outputText
+    event.sourceMap = processed.sourceMapText
+  })
+}


### PR DESCRIPTION
Wanted to try Pundle in my TypeScript project, so I took a stab at making a plugin.  I basically copied the babel plugin, but swapped the transform command for TypeScript's `transpileModule`.

Outstanding issues:

- It can't find a loader for `.ts` files.
  ```
  Pundle:Error AssertionError: Unrecognized extension '.ts' for '~/Projects/pundle/packages/test/src/index.ts'
  ```
