### PR TITLE
:memo: Fixed package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Here are some quick links for you
 - [Pundle](https://github.com/motion/pundle/blob/master/packages/pundle/README.md)
 - [Pundle Dev Server](https://github.com/motion/pundle/blob/master/packages/dev/README.md)
 - [Babel Plugin](https://github.com/motion/pundle/blob/master/packages/babel/README.md)
+- [TypeScript Plugin](https://github.com/motion/pundle/blob/master/packages/typescript/README.md)
 - [NPM Installer Plugin](https://github.com/motion/pundle/blob/master/packages/npm-installer/README.md)
-
 
 ## License
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -12,7 +12,7 @@ npm install --save typescript-pundle
 
 ```
 pundle.loadPlugins([
-  ['pundle-typescript', {
+  ['typescript-pundle', {
     ignored?: RegExp,
     extensions?: ['.ts'],
     config: {
@@ -21,7 +21,7 @@ pundle.loadPlugins([
   }]
 ]).then(() => {
   pundle.loadLoaders([
-    { extensions: ['.ts'], loader: require('pundle/lib/loaders/javascript').default },
+    { extensions: ['.ts', '.tsx'], loader: require('pundle/lib/loaders/javascript').default },
   ])
   console.log('Plugin loaded successfully')
 )


### PR DESCRIPTION
I just noticed the package was published under `typescript-pundle`, but the docs said `pundle-typescript`.  This changes the docs to match package.json.

(I also noticed that the version probably should have been 1.2.0, in keeping with your Lerna config, but that might not be worth changing now.)