### PR TITLE
:bug: fix HMR in Safari

### DIFF
--- a/packages/dev/src/browser/index.js
+++ b/packages/dev/src/browser/index.js
@@ -2,7 +2,7 @@
 
 function requestForUpdates() {
   return new Promise(function(resolve, reject) {
-    const xhr = new XMLHttpRequest()
+    var xhr = new XMLHttpRequest()
     xhr.open('GET', SB_PUNDLE_HMR_PATH, true)
     xhr.onload = function() {
       if (xhr.status >= 200 && xhr.status < 400) {


### PR DESCRIPTION
I get this error in Pundle@1 when I try to use HMR in Safari:

    SyntaxError: Unexpected keyword 'const'. Const declarations are not supported in strict mode.

Looks like this is the equivalent file in pundle@2, so I'm pre-emptively fixing it. :stuck_out_tongue_closed_eyes: