### PR TITLE
:bug: fix TypeScript sourcemaps

### DIFF
--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -33,6 +33,6 @@ export default function getTypeScriptTransformer(pundle: Object, parameters: Obj
     )
 
     event.contents = processed.outputText
-    event.sourceMap = processed.sourceMapText
+    event.sourceMap = JSON.parse(processed.sourceMapText);
   })
 }


### PR DESCRIPTION
TypeScript emits source maps as a string, so they need to be parsed first.