### PR TITLE
Make Component API more type-safe and predictable

### DIFF
--- a/packages/api/types.js
+++ b/packages/api/types.js
@@ -122,4 +122,49 @@ export type Watcher = {
   defaultConfig: Object,
 }
 
+export type Preset = Array<{ component: string | Object, config: Object, name: string }>
+export type Loaded = [Object, Object]
+export type Loadable = string | [string, Object] | [Object, Object]
+// NOTE: This is the config is after transformation, not what Pundle accepts
+export type PundleConfig = {
+  debug: boolean,
+  entry: Array<string>,
+  output: {
+    sourceMap?: boolean,
+    publicRoot?: string,
+    bundlePath?: string,
+    sourceMapPath?: string,
+    rootDirectory?: string,
+  },
+  server: {
+    port?: number,
+    hmrHost?: string,
+    hmrPath?: string,
+    bundlePath?: string,
+    sourceMapPath?: string,
+    rootDirectory: string,
+    redirectNotFoundToIndex?: boolean,
+  },
+  presets: Array<Loadable>,
+  watcher: {
+    usePolling: boolean,
+  },
+  components: Array<Loadable>,
+  rootDirectory: string,
+  replaceVariables: Object, // <string, Object>
+}
+
+export type Context = {
+  config: PundleConfig,
+  report(content: Error | FileIssue | MessageIssue): Promise<void>,
+  resolveAdvanced(request: string, from: ?string, cached: boolean): Promise<ResolverResult>,
+  resolve(request: string, from: ?string, cached: boolean): Promise<string>,
+  generate(chunks: Array<FileChunk>, generateConfig: Object): Promise<Array<GeneratorResult>>,
+  serialize(): string,
+  unserialize(contents: string, force: boolean): void,
+  getUID(label: string): number,
+  getChunk(entries: ?Array<FileImport>, label: ?string, imports: ?Array<FileImport>, files: ?Map<string, File>): FileChunk,
+  getImportRequest(request: string, from: ?string): FileImport,
+}
+
 export type ComponentAny = Loader | Plugin | Resolver | Reporter | Generator | Transformer | PostTransformer | Watcher | ChunkTransformer

--- a/packages/api/types.js
+++ b/packages/api/types.js
@@ -162,7 +162,6 @@ export type Context = {
   generate(chunks: Array<FileChunk>, generateConfig: Object): Promise<Array<GeneratorResult>>,
   serialize(): string,
   unserialize(contents: string, force: boolean): void,
-  getUID(label: string): number,
   getChunk(entries: ?Array<FileImport>, label: ?string, imports: ?Array<FileImport>, files: ?Map<string, File>): FileChunk,
   getImportRequest(request: string, from: ?string): FileImport,
 }

--- a/packages/dev/src/index.js
+++ b/packages/dev/src/index.js
@@ -121,7 +121,7 @@ class Server {
         },
       }],
       createWatcher({
-        tick: (_: Object, file: File) => {
+        tick: (_: Object, __: Object, file: File) => {
           if (booted && file.filePath !== Helpers.browserFile) {
             this.state.changed.set(file.filePath, file)
           }
@@ -129,7 +129,7 @@ class Server {
         ready: () => {
           this.report('Server initialized successfully')
         },
-        compile: async (_: Object, chunks: Array<FileChunk>, files: Map<string, File>) => {
+        compile: async (_: Object, __: Object, chunks: Array<FileChunk>, files: Map<string, File>) => {
           this.state.files = files
           this.state.chunks = chunks
           if (this.connections.size && this.state.changed.size) {

--- a/packages/loader-js/package.json
+++ b/packages/loader-js/package.json
@@ -23,8 +23,5 @@
     "babel-types": "^6.19.0",
     "babylon": "^6.16.1",
     "pundle-api": "2.0.0-beta16"
-  },
-  "devDependencies": {
-    "pundle": "2.0.0-beta16"
   }
 }

--- a/packages/loader-js/src/helpers.js
+++ b/packages/loader-js/src/helpers.js
@@ -1,8 +1,7 @@
 /* @flow */
 
 import * as t from 'babel-types'
-import type Context from 'pundle/src/context'
-import type { File, FileChunk } from 'pundle-api/types'
+import type { File, Context, FileChunk } from 'pundle-api/types'
 
 export function getName(obj: Object): string {
   if (typeof obj.name === 'string') {

--- a/packages/loader-json/src/index.js
+++ b/packages/loader-json/src/index.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import { createLoader, shouldProcess, MessageIssue } from 'pundle-api'
-import type { File } from 'pundle-api/types'
+import type { Context, File } from 'pundle-api/types'
 
-export default createLoader(function(config: Object, file: File) {
-  if (!shouldProcess(this.config.rootDirectory, file.filePath, config)) {
+export default createLoader(function(context: Context, config: Object, file: File) {
+  if (!shouldProcess(context.config.rootDirectory, file.filePath, config)) {
     return null
   }
 

--- a/packages/loader-url/src/index.js
+++ b/packages/loader-url/src/index.js
@@ -2,10 +2,10 @@
 
 import fileSystem from 'sb-fs'
 import { createLoader, shouldProcess } from 'pundle-api'
-import type { File } from 'pundle-api/types'
+import type { Context, File } from 'pundle-api/types'
 
-export default createLoader(async function(config: Object, file: File) {
-  if (!shouldProcess(this.config.rootDirectory, file.filePath, config)) {
+export default createLoader(async function(context: Context, config: Object, file: File) {
+  if (!shouldProcess(context.config.rootDirectory, file.filePath, config)) {
     return null
   }
   const contents = await fileSystem.readFile(file.filePath)

--- a/packages/plugin-commons-chunk/src/index.js
+++ b/packages/plugin-commons-chunk/src/index.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import { createChunkTransformer } from 'pundle-api'
-import type { File, FileChunk, ChunkTransformerResult } from 'pundle-api/types'
+import type { File, FileChunk, Context, ChunkTransformerResult } from 'pundle-api/types'
 
-export default createChunkTransformer(function(config: Object, chunks: Array<FileChunk>): ChunkTransformerResult {
+export default createChunkTransformer(function(context: Context, config: Object, chunks: Array<FileChunk>): ChunkTransformerResult {
   const known: Set<string> = new Set()
   const newChunkFiles: Map<string, File> = new Map()
 
@@ -27,8 +27,7 @@ export default createChunkTransformer(function(config: Object, chunks: Array<Fil
     // No common files found
     return
   }
-  // NOTE: Order is important, commons should be loaded before others
-  chunks.unshift(this.getChunk(null, config.name, null, newChunkFiles))
+  chunks.push(context.getChunk(null, config.name, null, newChunkFiles))
 }, {
   name: 'common',
 })

--- a/packages/plugin-dedupe/src/index.js
+++ b/packages/plugin-dedupe/src/index.js
@@ -3,15 +3,16 @@
 import Path from 'path'
 import semver from 'semver'
 import { createResolver, getRelativeFilePath, MessageIssue } from 'pundle-api'
+import type { Context } from 'pundle-api'
 import * as Helpers from './helpers'
 
 const memoryCache = new Map()
 
-export default createResolver(async function(config: Object, givenRequest: string, fromFile: ?string, cached: boolean = false) {
+export default createResolver(async function(context: Context, config: Object, givenRequest: string, fromFile: ?string, cached: boolean = false) {
   if (givenRequest.slice(0, 1) === '.' || Path.isAbsolute(givenRequest)) {
     return null
   }
-  const result = await this.resolveAdvanced(givenRequest, fromFile, cached)
+  const result = await context.resolveAdvanced(givenRequest, fromFile, cached)
   if (!result || !result.targetManifest || !result.targetManifest.version) {
     return null
   }
@@ -30,7 +31,7 @@ export default createResolver(async function(config: Object, givenRequest: strin
         matched = entry
       }
     } else if (process.env.DEBUG_PUNDLE_PLUGIN_DEDUPE) {
-      this.report(new MessageIssue(`${moduleName} v${entry.version} did not match ${cacheVersion} from ${getRelativeFilePath(fromFile, this.config.rootDirectory)}`, 'info'))
+      context.report(new MessageIssue(`${moduleName} v${entry.version} did not match ${cacheVersion} from ${getRelativeFilePath(fromFile, context.config.rootDirectory)}`, 'info'))
     }
   }
   if (!matched) {

--- a/packages/plugin-dedupe/src/index.js
+++ b/packages/plugin-dedupe/src/index.js
@@ -3,7 +3,7 @@
 import Path from 'path'
 import semver from 'semver'
 import { createResolver, getRelativeFilePath, MessageIssue } from 'pundle-api'
-import type { Context } from 'pundle-api'
+import type { Context } from 'pundle-api/types'
 import * as Helpers from './helpers'
 
 const memoryCache = new Map()

--- a/packages/plugin-npm-installer/src/index.js
+++ b/packages/plugin-npm-installer/src/index.js
@@ -3,7 +3,7 @@
 import Path from 'path'
 import promiseDefer from 'promise.defer'
 import { createResolver, shouldProcess, MessageIssue } from 'pundle-api'
-import type { Context } from 'pundle-api'
+import type { Context } from 'pundle-api/types'
 
 import { getModuleName } from './helpers'
 import Installer from './installer'
@@ -24,7 +24,7 @@ export default createResolver(async function(context: Context, config: Object, g
   }
 
   try {
-    return await context.resolve(givenRequest, fromFile)
+    return await context.resolve(givenRequest, fromFile, true)
   } catch (_) { /* No Op */ }
   if (!shouldProcess(context.config.rootDirectory, fromFile, config)) {
     return null

--- a/packages/plugin-npm-installer/src/index.js
+++ b/packages/plugin-npm-installer/src/index.js
@@ -3,6 +3,7 @@
 import Path from 'path'
 import promiseDefer from 'promise.defer'
 import { createResolver, shouldProcess, MessageIssue } from 'pundle-api'
+import type { Context } from 'pundle-api'
 
 import { getModuleName } from './helpers'
 import Installer from './installer'
@@ -17,21 +18,21 @@ import Installer from './installer'
 // If invocation was successful, try resolving again and output whatever you get (do not catch)
 
 const locks = new Map()
-export default createResolver(async function(config: Object, givenRequest: string, fromFile: ?string) {
+export default createResolver(async function(context: Context, config: Object, givenRequest: string, fromFile: ?string) {
   if (givenRequest.slice(0, 1) === '.' || Path.isAbsolute(givenRequest)) {
     return null
   }
 
   try {
-    return await this.resolve(givenRequest, fromFile)
+    return await context.resolve(givenRequest, fromFile)
   } catch (_) { /* No Op */ }
-  if (!shouldProcess(this.config.rootDirectory, fromFile, config)) {
+  if (!shouldProcess(context.config.rootDirectory, fromFile, config)) {
     return null
   }
 
   const moduleName = getModuleName(givenRequest)
   try {
-    await this.resolve(`${moduleName}/package.json`, fromFile)
+    await context.resolve(`${moduleName}/package.json`, fromFile)
     return null
   } catch (_) { /* No Op */ }
 
@@ -44,23 +45,23 @@ export default createResolver(async function(config: Object, givenRequest: strin
 
   try {
     if (!config.silent) {
-      this.report(new MessageIssue(`Installing '${moduleName}' in ${this.config.rootDirectory}`, 'info'))
+      context.report(new MessageIssue(`Installing '${moduleName}' in ${context.config.rootDirectory}`, 'info'))
     }
     config.beforeInstall(moduleName)
     let error = null
     try {
-      await Installer.install(moduleName, config.save, this.config.rootDirectory)
+      await Installer.install(moduleName, config.save, context.config.rootDirectory)
     } catch (_) {
       error = _
     }
     config.afterInstall(moduleName, error)
     if (error && !config.silent) {
-      this.report(new MessageIssue(`Failed to install '${moduleName}'`, 'error'))
+      context.report(new MessageIssue(`Failed to install '${moduleName}'`, 'error'))
     } else if (!error && !config.silent) {
-      this.report(new MessageIssue(`Installed '${moduleName}' successfully`, 'info'))
+      context.report(new MessageIssue(`Installed '${moduleName}' successfully`, 'info'))
     }
   } finally {
-    deferred.resolve(this.resolve(givenRequest, fromFile, false))
+    deferred.resolve(context.resolve(givenRequest, fromFile, false))
   }
   // This is, unfortunately, required. Making it wait on all installations saves us from a few race conditions
   await Promise.all(locks.values())

--- a/packages/post-transformer-uglify/src/index.js
+++ b/packages/post-transformer-uglify/src/index.js
@@ -1,8 +1,9 @@
 /* @flow */
 
 import { createPostTransformer, MessageIssue } from 'pundle-api'
+import type { Context } from 'pundle-api/types'
 
-export default createPostTransformer(async function(config: Object, contents: string) {
+export default createPostTransformer(async function(context: Context, config: Object, contents: string) {
   let uglifyPath
   try {
     uglifyPath = await this.resolve('uglify-js')

--- a/packages/post-transformer-uglify/src/index.js
+++ b/packages/post-transformer-uglify/src/index.js
@@ -6,7 +6,7 @@ import type { Context } from 'pundle-api/types'
 export default createPostTransformer(async function(context: Context, config: Object, contents: string) {
   let uglifyPath
   try {
-    uglifyPath = await this.resolve('uglify-js')
+    uglifyPath = await context.resolve('uglify-js', null, true)
   } catch (_) {
     throw new MessageIssue('Unable to find uglify-js in project root', 'error')
   }

--- a/packages/pundle/src/compilation/index.js
+++ b/packages/pundle/src/compilation/index.js
@@ -210,7 +210,7 @@ export default class Compilation {
       }
       for (const entry of Helpers.filterComponents(this.context.components, 'watcher')) {
         try {
-          await Helpers.invokeComponent(this, entry, 'compile', [], cloned, files)
+          await Helpers.invokeComponent(this.context, entry, 'compile', [], cloned, files)
         } catch (error) {
           this.context.report(error)
         }
@@ -282,7 +282,7 @@ export default class Compilation {
 
     for (const entry of Helpers.filterComponents(this.context.components, 'watcher')) {
       try {
-        await Helpers.invokeComponent(this, entry, 'ready', [])
+        await Helpers.invokeComponent(this.context, entry, 'ready', [])
       } catch (error) {
         this.context.report(error)
       }

--- a/packages/pundle/src/context/helpers.js
+++ b/packages/pundle/src/context/helpers.js
@@ -28,7 +28,7 @@ export function invokeComponent(context: Context, entry: ComponentEntry, method:
     }
     return item
   })
-  return entry.component[method]([context, Object.assign({}, entry.component.defaultConfig, entry.config, ...configs)].concat(parameters))
+  return entry.component[method].apply(null, [context, Object.assign({}, entry.component.defaultConfig, entry.config, ...configs)].concat(parameters))
 }
 
 // NOTE: The reason we only count in loaders and not transformers even though they could be useful

--- a/packages/pundle/src/context/helpers.js
+++ b/packages/pundle/src/context/helpers.js
@@ -3,7 +3,7 @@
 import unique from 'lodash.uniq'
 import invariant from 'assert'
 import sourceMap from 'source-map'
-import type { File } from 'pundle-api/types'
+import type { Context, File } from 'pundle-api/types'
 import type { ComponentEntry } from '../../types'
 
 export function filterComponents(components: Set<ComponentEntry>, type: string): Array<ComponentEntry> {
@@ -20,7 +20,7 @@ export function filterComponents(components: Set<ComponentEntry>, type: string):
 // - Validate method to exist on component
 // - Clone all Objects in the parameters to make sure components can't override originals
 // - Invoke the method requested on component with merged configs as first arg and params as others
-export function invokeComponent(thisArg: any, entry: ComponentEntry, method: string, configs: Array<Object>, ...givenParameters: Array<any>) {
+export function invokeComponent(context: Context, entry: ComponentEntry, method: string, configs: Array<Object>, ...givenParameters: Array<any>) {
   invariant(typeof entry.component[method] === 'function', `Component method '${method}' does not exist on given component`)
   const parameters = givenParameters.map(function(item) {
     if (item && item.constructor === Object) {
@@ -28,7 +28,7 @@ export function invokeComponent(thisArg: any, entry: ComponentEntry, method: str
     }
     return item
   })
-  return entry.component[method].apply(thisArg, [Object.assign({}, entry.component.defaultConfig, entry.config, ...configs)].concat(parameters))
+  return entry.component[method]([context, Object.assign({}, entry.component.defaultConfig, entry.config, ...configs)].concat(parameters))
 }
 
 // NOTE: The reason we only count in loaders and not transformers even though they could be useful

--- a/packages/pundle/src/context/index.js
+++ b/packages/pundle/src/context/index.js
@@ -3,10 +3,10 @@
 import reporterCli from 'pundle-reporter-default'
 import { Disposable } from 'sb-event-kit'
 import { version as API_VERSION, getRelativeFilePath, MessageIssue } from 'pundle-api'
-import type { File, FileChunk, ComponentAny, FileImport, ResolverResult, GeneratorResult } from 'pundle-api/types'
+import type { File, FileChunk, ComponentAny, PundleConfig, FileImport, ResolverResult, GeneratorResult } from 'pundle-api/types'
 
 import * as Helpers from './helpers'
-import type { ComponentEntry, PundleConfig } from '../../types'
+import type { ComponentEntry } from '../../types'
 
 export default class Context {
   uid: Map<string, number>;

--- a/packages/pundle/src/helpers.js
+++ b/packages/pundle/src/helpers.js
@@ -7,8 +7,7 @@ import Path from 'path'
 import Crypto from 'crypto'
 import promisify from 'sb-promisify'
 import { getRelativeFilePath, MessageIssue } from 'pundle-api'
-import type { File } from 'pundle-api/types'
-import type { PundleConfig, Loadable, Loaded } from '../types'
+import type { File, PundleConfig, Loadable, Loaded } from 'pundle-api/types'
 
 const resolve = promisify(require('resolve'))
 

--- a/packages/pundle/src/index.js
+++ b/packages/pundle/src/index.js
@@ -4,13 +4,12 @@ import Path from 'path'
 import invariant from 'assert'
 import ConfigFile from 'sb-config-file'
 import { CompositeDisposable, Emitter } from 'sb-event-kit'
-import type { File, FileChunk, GeneratorResult } from 'pundle-api/types'
+import type { File, FileChunk, PundleConfig, Loadable, GeneratorResult } from 'pundle-api/types'
 import type { Disposable } from 'sb-event-kit'
 
 import * as Helpers from './helpers'
 import Context from './context'
 import Compilation from './compilation'
-import type { PundleConfig, Loadable } from '../types'
 
 const UNIQUE_SIGNATURE_OBJ = {}
 

--- a/packages/pundle/types.js
+++ b/packages/pundle/types.js
@@ -1,47 +1,14 @@
 /* @flow */
 
-import type { ComponentAny } from 'pundle-api/types'
+import type { PundleConfig, ComponentAny } from 'pundle-api/types'
 
 export type ComponentEntry = {
   config: Object,
   component: ComponentAny,
 }
 
-export type Preset = Array<{ component: string | Object, config: Object, name: string }>
-export type Loaded = [Object, Object]
-export type Loadable = string | [string, Object] | [Object, Object]
-
-// NOTE: This is the config after transformation, not what Pundle accepts
-export type PundleConfig = {
-  debug: boolean,
-  entry: Array<string>,
-  output: {
-    sourceMap?: boolean,
-    publicRoot?: string,
-    bundlePath?: string,
-    sourceMapPath?: string,
-    rootDirectory?: string,
-  },
-  server: {
-    port?: number,
-    hmrHost?: string,
-    hmrPath?: string,
-    bundlePath?: string,
-    sourceMapPath?: string,
-    rootDirectory: string,
-    redirectNotFoundToIndex?: boolean,
-  },
-  presets: Array<Loadable>,
-  watcher: {
-    usePolling: boolean,
-  },
-  components: Array<Loadable>,
-  rootDirectory: string,
-  replaceVariables: Object, // <string, Object>
-}
-
-// NOTE: Not used anywhere but this is what Pundle supports publically
-export type PublicPundleConfig = {
+// NOTE: This is what pundle accepts and can work with in Pundle.get()
+export type PublicPundleConfig = PundleConfig & {
   configFileName?: string,
   enableConfigFile: boolean,
 }

--- a/packages/reporter-default/src/index.js
+++ b/packages/reporter-default/src/index.js
@@ -2,7 +2,6 @@
 
 import chalk from 'chalk'
 import codeFrame from 'babel-code-frame'
-import invariant from 'assert'
 import { createReporter } from 'pundle-api'
 import type { Context, FileIssue, MessageIssue } from 'pundle-api/types'
 
@@ -25,7 +24,9 @@ const SEVERITIES = {
 }
 
 export default createReporter(async function(context: Context, config: Object, error: Error | FileIssue | MessageIssue) {
-  invariant(typeof error === 'object' && error, 'Error must be an object')
+  if (typeof error !== 'object' || !error) {
+    throw new Error(`Expected Error to be an object, got ${typeof error}:${String(error)}`)
+  }
 
   let errorMessage = error.message
   const severity = SEVERITIES[typeof error.severity === 'string' ? error.severity : 'error']

--- a/packages/reporter-default/src/index.js
+++ b/packages/reporter-default/src/index.js
@@ -4,7 +4,7 @@ import chalk from 'chalk'
 import codeFrame from 'babel-code-frame'
 import invariant from 'assert'
 import { createReporter } from 'pundle-api'
-import type { FileIssue, MessageIssue } from 'pundle-api/types'
+import type { Context, FileIssue, MessageIssue } from 'pundle-api/types'
 
 const SEVERITIES = {
   info: {
@@ -24,7 +24,7 @@ const SEVERITIES = {
   },
 }
 
-export default createReporter(async function(config: Object, error: Error | FileIssue | MessageIssue) {
+export default createReporter(async function(context: Context, config: Object, error: Error | FileIssue | MessageIssue) {
   invariant(typeof error === 'object' && error, 'Error must be an object')
 
   let errorMessage = error.message
@@ -41,7 +41,7 @@ export default createReporter(async function(config: Object, error: Error | File
   } else if (error.constructor.name === 'SyntaxError') {
     const lastLine = error.stack.split(/\n/).shift()
     errorMessage += ` in ${lastLine}`
-  } else if (this.config.debug) {
+  } else if (context.config.debug) {
     stack = error.stack
   }
 

--- a/packages/resolver-default/src/helpers.js
+++ b/packages/resolver-default/src/helpers.js
@@ -4,6 +4,7 @@ import Path from 'path'
 import resolve from 'resolve'
 import memoize from 'sb-memoize'
 import fileSystem from 'sb-fs'
+import type { PundleConfig } from 'pundle-api/types'
 
 export const MODULE_SEPARATOR_REGEX = /\/|\\/
 
@@ -32,7 +33,7 @@ export function isModuleOnly(request: string): boolean {
 // Cut path into half based on module directories, and only use the right side of it
 // Cut path into half based on rootDirectory, do not search outside the root directory if item is INSIDE it
 
-const findManifestCached = memoize(async function (givenFileDirectory: string, config: Object, cached: boolean, pundleConfig: Object): Promise<?string> {
+const findManifestCached = memoize(async function (givenFileDirectory: string, config: Object, cached: boolean, pundleConfig: PundleConfig): Promise<?string> {
   let fileDirectory = givenFileDirectory
   if (fileDirectory.slice(-1) === '/') {
     fileDirectory = fileDirectory.slice(0, -1)
@@ -65,7 +66,7 @@ const findManifestCached = memoize(async function (givenFileDirectory: string, c
   return await findManifestCached(Path.dirname(fileDirectory), config, cached, pundleConfig)
 }, { async: true })
 
-export function findManifest(fileDirectory: string, config: Object, cached: boolean, pundleConfig: Object): Promise<?string> {
+export function findManifest(fileDirectory: string, config: Object, cached: boolean, pundleConfig: PundleConfig): Promise<?string> {
   if (!cached) {
     const cachedValue = findManifestCached.getCache([fileDirectory, config, cached, pundleConfig])
     if (typeof cachedValue === 'string') {
@@ -78,7 +79,7 @@ export function findManifest(fileDirectory: string, config: Object, cached: bool
 // Spec:
 // Keep a rootDirectory in manifest
 // Return empty object if manifest is not found, parsed manifest contents otherwise
-const getManifestCached = memoize(async function(fileDirectory: string, config: Object, cached: boolean, pundleConfig: Object): Promise<Object> {
+const getManifestCached = memoize(async function(fileDirectory: string, config: Object, cached: boolean, pundleConfig: PundleConfig): Promise<Object> {
   let manifest = {}
   const manifestPath = await findManifest(fileDirectory, config, cached, pundleConfig)
   if (manifestPath) {
@@ -88,7 +89,7 @@ const getManifestCached = memoize(async function(fileDirectory: string, config: 
   return manifest
 }, { async: true })
 
-export function getManifest(fileDirectory: string, config: Object, cached: boolean, pundleConfig: Object): Promise<Object> {
+export function getManifest(fileDirectory: string, config: Object, cached: boolean, pundleConfig: PundleConfig): Promise<Object> {
   if (!cached) {
     const cachedValue = getManifestCached.getCache([fileDirectory, config, cached, pundleConfig])
     if (typeof cachedValue === 'string') {

--- a/packages/resolver-default/src/index.js
+++ b/packages/resolver-default/src/index.js
@@ -4,6 +4,7 @@ import Path from 'path'
 import fileSystem from 'sb-fs'
 import pundleBrowser from 'pundle-browser'
 import { createResolver } from 'pundle-api'
+import type { Context } from 'pundle-api/types'
 import { MODULE_SEPARATOR_REGEX, getManifest, isModuleRequested, isModuleOnly, promisedResolve } from './helpers'
 
 // Spec:
@@ -69,16 +70,16 @@ function resolveInManifestAndAlias(request: string, alias: Object, manifest: Obj
 // If module was whole, resolve it with target browser field
 // If module was relative, resolve it with source browser field
 
-export default createResolver(async function(config: Object, givenRequest: string, fromFile: ?string, cached: boolean) {
+export default createResolver(async function(context: Context, config: Object, givenRequest: string, fromFile: ?string, cached: boolean) {
   let request = givenRequest
   let fromDirectory = ''
-  const manifest = { rootDirectory: this.config.rootDirectory }
+  const manifest = { rootDirectory: context.config.rootDirectory }
   const extensions = config.extensions || config.knownExtensions
   const targetManifest = {}
 
   if (fromFile) {
     fromDirectory = Path.dirname(fromFile)
-    Object.assign(manifest, await getManifest(fromDirectory, config, cached, this.config))
+    Object.assign(manifest, await getManifest(fromDirectory, config, cached, context.config))
   }
 
   if (isModuleRequested(request)) {
@@ -90,7 +91,7 @@ export default createResolver(async function(config: Object, givenRequest: strin
     return { filePath: pundleBrowser[request], sourceManifest: manifest, targetManifest: null }
   }
   let resolved = await promisedResolve(request, {
-    basedir: fromDirectory || this.config.rootDirectory,
+    basedir: fromDirectory || context.config.rootDirectory,
     extensions: extensions.map(i => `.${i}`),
     readFile: (path, callback) => {
       fileSystem.readFile(path).then(function(result) {

--- a/packages/transformer-babel/src/index.js
+++ b/packages/transformer-babel/src/index.js
@@ -10,7 +10,7 @@ export default createTransformer(async function(context: Context, config: Object
 
   let babelPath = config.babelPath
   try {
-    babelPath = await context.resolve(babelPath, null)
+    babelPath = await context.resolve(babelPath, null, true)
   } catch (_) {
     throw new MessageIssue('Unable to find babel-core', 'error')
   }

--- a/packages/transformer-babel/src/index.js
+++ b/packages/transformer-babel/src/index.js
@@ -1,16 +1,16 @@
 /* @flow */
 
 import { createTransformer, shouldProcess, getRelativeFilePath, FileIssue, MessageIssue } from 'pundle-api'
-import type { File } from 'pundle-api/types'
+import type { File, Context } from 'pundle-api/types'
 
-export default createTransformer(async function(config: Object, file: File) {
-  if (!shouldProcess(this.config.rootDirectory, file.filePath, config)) {
+export default createTransformer(async function(context: Context, config: Object, file: File) {
+  if (!shouldProcess(context.config.rootDirectory, file.filePath, config)) {
     return null
   }
 
   let babelPath = config.babelPath
   try {
-    babelPath = await this.resolve(babelPath)
+    babelPath = await context.resolve(babelPath, null)
   } catch (_) {
     throw new MessageIssue('Unable to find babel-core', 'error')
   }
@@ -27,7 +27,7 @@ export default createTransformer(async function(config: Object, file: File) {
       sourceFileName: file.filePath,
     }))
   } catch (error) {
-    const errorMessage = `${error.message} in ${getRelativeFilePath(file.filePath, this.config.rootDirectory)}`
+    const errorMessage = `${error.message} in ${getRelativeFilePath(file.filePath, context.config.rootDirectory)}`
     if (error.loc) {
       throw new FileIssue(file.filePath, file.contents, error.loc.line, error.loc.column + 1, errorMessage, 'error')
     } else {

--- a/packages/transformer-typescript/src/index.js
+++ b/packages/transformer-typescript/src/index.js
@@ -11,7 +11,7 @@ export default createTransformer(async function(context: Context, config: Object
 
   let typescriptPath = config.typescriptPath
   try {
-    typescriptPath = await context.resolve(typescriptPath, null)
+    typescriptPath = await context.resolve(typescriptPath, null, true)
   } catch (_) {
     throw new MessageIssue('Unable to find typescript in project root', 'error')
   }

--- a/packages/transformer-typescript/src/index.js
+++ b/packages/transformer-typescript/src/index.js
@@ -1,17 +1,17 @@
 /* @flow */
 
 import { createTransformer, shouldProcess, MessageIssue } from 'pundle-api'
-import type { File } from 'pundle-api/types'
+import type { File, Context } from 'pundle-api/types'
 
 // TODO: Implement watching and everything
-export default createTransformer(async function(config: Object, file: File) {
-  if (!shouldProcess(this.config.rootDirectory, file.filePath, config)) {
+export default createTransformer(async function(context: Context, config: Object, file: File) {
+  if (!shouldProcess(context.config.rootDirectory, file.filePath, config)) {
     return null
   }
 
   let typescriptPath = config.typescriptPath
   try {
-    typescriptPath = await this.resolve(typescriptPath)
+    typescriptPath = await context.resolve(typescriptPath, null)
   } catch (_) {
     throw new MessageIssue('Unable to find typescript in project root', 'error')
   }


### PR DESCRIPTION
We were previously calling component callbacks with `Context` as their thisVar, it was un-typeable and therefore more prone to out-of-sync errors.

This PR moves `Context` from thisVar, to the first parameter of component callbacks, and adds it's type to `pundle-api/types` so each component knows what's in there. It has already helped me catch a few bugs in out-of-sync internal parts